### PR TITLE
gem install omniauth-rails_csrf_protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,4 +71,5 @@ end
 
 gem 'devise'
 gem 'jquery-rails'
+gem "omniauth-rails_csrf_protection"
 gem 'rspotify'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,9 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     parallel (1.18.0)
     parser (2.6.5.0)
@@ -311,6 +314,7 @@ DEPENDENCIES
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
+  omniauth-rails_csrf_protection
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)


### PR DESCRIPTION
# What
gem "omniauth-rails_csrf_protection"をインストール

# Why
"OmniAuth" の脆弱性対策のため